### PR TITLE
Ensure URI is percent-encoded before sending it off to OpenAM

### DIFF
--- a/ngx_http_am_module.c
+++ b/ngx_http_am_module.c
@@ -627,9 +627,12 @@ static char* ngx_http_am_get_url(ngx_http_request_t *r){
         len += ngx_cycle->hostname.len;
     }
 
-    // The code below is perhaps the most untested thing in the
-    // universe. Alternatively just use r->args_start + r->uri_start
-    // and trim away the freaking URL query.
+    // Code below escapes the URI before sending it off to the OpenAM
+    // agent. This has the potential effect of fixing the way said
+    // agent handles colon (":") characters present in any place in
+    // URI. Alternative approaches are either to completely remove
+    // colons or remove URL query paramaters (identified by r->args,
+    // r->args_start and r->uri_start).
 
     // First we need to find out the length of the escaped string and
     // only then can we proceed to actually escaping it

--- a/ngx_http_am_module.c
+++ b/ngx_http_am_module.c
@@ -628,11 +628,11 @@ static char* ngx_http_am_get_url(ngx_http_request_t *r){
     }
 
     // Code below escapes the URI before sending it off to the OpenAM
-    // agent. This has the potential effect of fixing the way said
-    // agent handles colon (":") characters present in any place in
-    // URI. Alternative approaches are either to completely remove
-    // colons or remove URL query paramaters (identified by r->args,
-    // r->args_start and r->uri_start).
+    // agent. This has the effect of fixing the way said agent handles
+    // colon (":") characters present in any place in URI. Alternative
+    // approaches are either to completely remove colons or remove URL
+    // query parameters (identified by r->args, r->args_start and
+    // r->uri_start).
 
     // First we need to find out the length of the escaped string and
     // only then can we proceed to actually escaping it

--- a/ngx_http_am_module.c
+++ b/ngx_http_am_module.c
@@ -648,7 +648,7 @@ static char* ngx_http_am_get_url(ngx_http_request_t *r){
      * trailing slashs.
      * see https://bugster.forgerock.org/jira/browse/OPENAM-2969
      */
-    for(i = path_len; i >= 0; i--){
+    for(i = path_len - 1; i >= 0; i--){
         if(path[i] == '/'){
             path[i] = '\0';
         }else{

--- a/ngx_http_am_module.c
+++ b/ngx_http_am_module.c
@@ -166,10 +166,10 @@ ngx_http_am_get_post_data(void **args, char **rbuf){
 static am_status_t
 ngx_http_am_set_user(void **args, const char *user)
 {
-    if (!user) { 
-      // user may be null in case of notenforced_url_attributes_enable 
-      return AM_SUCCESS; 
-    } 
+    if (!user) {
+      // user may be null in case of notenforced_url_attributes_enable
+      return AM_SUCCESS;
+    }
     am_status_t st = AM_SUCCESS;
     ngx_http_request_t *r = args[0];
     ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0,


### PR DESCRIPTION
This pull request introduces percent encoding of URIs before they're sent off to the OpenAM (through agent). This fixes an issue where upon encountering a colon character in the URI (either in path or the query part of it) all remaining characters are overwritten with a sequence of "443", thus causing OpenAM to reject policies.